### PR TITLE
Fixes options for research spread being inverted on website.

### DIFF
--- a/client/partials/settings/research.ejs
+++ b/client/partials/settings/research.ejs
@@ -64,7 +64,7 @@
                     <% if (typeof gameSettings !== "object" || (typeof gameSettings === "object" && gameSettings.startingResearch == 0)) { %> checked <% } %>
                 >
                 <label class="form-check-label" for="starting_research_radio_0">
-                    Spread evenly across schools
+                    Randomly spread
                 </label>
             </div>
             
@@ -73,7 +73,7 @@
                     <% if (typeof gameSettings === "object" && gameSettings.startingResearch == 1) { %> checked <% } %>
                 >
                 <label class="form-check-label" for="starting_research_radio_1">
-                    Randomly spread
+                    Spread evenly across schools
                 </label>
             </div>
             

--- a/game_settings/dom5/prototypes/starting_research.js
+++ b/game_settings/dom5/prototypes/starting_research.js
@@ -16,9 +16,9 @@ function StartingResearch()
         var value = this.getValue();
 
         if (value == true)
-            return "Spread starting research";
+            return "Evenly spread starting research";
 
-        else return "Random starting research";
+        else return "Randomly spread starting research";
     };
     
     this.setValue = (input) =>

--- a/game_settings/dom5/prototypes/starting_research.js
+++ b/game_settings/dom5/prototypes/starting_research.js
@@ -16,9 +16,9 @@ function StartingResearch()
         var value = this.getValue();
 
         if (value == true)
-            return "Evenly spread starting research";
+            return "Evenly spread";
 
-        else return "Randomly spread starting research";
+        else return "Randomly spread";
     };
     
     this.setValue = (input) =>


### PR DESCRIPTION
Also renames the starting research options in the info panel. "Evenly spread" is more accurate than "Spread starting research".